### PR TITLE
Warn on invalid cards instead of silently ignoring them

### DIFF
--- a/src/bin/poker-odds.js
+++ b/src/bin/poker-odds.js
@@ -2,8 +2,8 @@
 
 import { version } from '../../package.json'
 import { calculateEquity } from '../calculate'
-import { RANK_NAMES, parseCards, percent, seconds, padStart, padEnd } from '../utils'
-import { getHands, hasOption, getOption, color, colorCards } from '../console'
+import { RANK_NAMES, parseCards, findInvalidCards, percent, seconds, padStart, padEnd } from '../utils'
+import { getHands, getInvalidHands, hasOption, getOption, color, colorCards } from '../console'
 
 if (hasOption('--version')) {
   log()
@@ -31,6 +31,11 @@ if (hasOption('--help')) {
 }
 
 const hands = getHands()
+const invalidHands = getInvalidHands()
+
+if (invalidHands.length > 0) {
+  log(`warning: ignoring invalid hand(s): ${invalidHands.join(', ')}`, 'yellow')
+}
 
 if (hands.length === 0) {
   console.error('You must pass in at least one valid hand eg AsAc')
@@ -38,6 +43,11 @@ if (hands.length === 0) {
 }
 
 const board = getOption('--board')
+const invalidBoardCards = findInvalidCards(board)
+
+if (invalidBoardCards.length > 0) {
+  log(`warning: ignoring invalid board card(s): ${invalidBoardCards.join(', ')}`, 'yellow')
+}
 const iterations = getOption('--iterations')
 const exhaustive = hasOption('--exhaustive')
 const start = +new Date()

--- a/src/console.js
+++ b/src/console.js
@@ -1,4 +1,5 @@
 const HAND_PATTERN = /^[AKQJT2-9.][schd.][AKQJT2-9.][schd.]$/
+const HAND_ATTEMPT_PATTERN = /^[AKQJT2-9][A-Za-z]([AKQJT2-9][A-Za-z])?$/
 const CONSOLE_COLORS = {
   black: '30',
   red: '31',
@@ -37,6 +38,17 @@ function colorCard (card) {
 
 export function getHands (argv = process.argv) {
   return argv.filter(string => HAND_PATTERN.test(string))
+}
+
+export function getInvalidHands (argv = process.argv) {
+  const consumed = new Set()
+  argv.forEach((s, i) => {
+    if (/^(-b|--board|-i|--iterations)$/.test(s)) consumed.add(i + 1)
+  })
+  return argv
+    .filter((_, i) => !consumed.has(i))
+    .filter(s => !s.startsWith('-') && !/^\d+$/.test(s))
+    .filter(s => HAND_ATTEMPT_PATTERN.test(s) && !HAND_PATTERN.test(s))
 }
 
 export function hasOption (option, argv = process.argv) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,6 +54,12 @@ export function parseCards (string) {
   return string.match(/[AKQJT2-9.][schd.]/g) || undefined
 }
 
+export function findInvalidCards (string) {
+  if (!string) return []
+  const candidates = string.match(/[AKQJT2-9][a-zA-Z]/g) || []
+  return candidates.filter(c => !/^[AKQJT2-9][schd]$/.test(c))
+}
+
 export function percent (number) {
   if (number === 0) {
     return '·'

--- a/test/console.js
+++ b/test/console.js
@@ -3,6 +3,7 @@ import {
   color,
   colorCards,
   getHands,
+  getInvalidHands,
   hasOption,
   getOption
 } from '../src/console'
@@ -23,6 +24,31 @@ test('colorCards', t => {
 test('getHands', t => {
   const argv = ['node', 'script.js', 'AsAd', 'KdQd', '--iterations', '100']
   t.deepEqual(getHands(argv), ['AsAd', 'KdQd'])
+})
+
+test('getInvalidHands detects invalid suit', t => {
+  const argv = ['node', 'script.js', 'Az', 'KdQd']
+  t.deepEqual(getInvalidHands(argv), ['Az'])
+})
+
+test('getInvalidHands detects invalid hand', t => {
+  const argv = ['node', 'script.js', 'AsAz', 'KdQd']
+  t.deepEqual(getInvalidHands(argv), ['AsAz'])
+})
+
+test('getInvalidHands ignores valid hands', t => {
+  const argv = ['node', 'script.js', 'AsAd', 'KdQd']
+  t.deepEqual(getInvalidHands(argv), [])
+})
+
+test('getInvalidHands ignores board value', t => {
+  const argv = ['node', 'script.js', 'AsAd', '--board', 'Az3s6d']
+  t.deepEqual(getInvalidHands(argv), [])
+})
+
+test('getInvalidHands ignores option flags and numbers', t => {
+  const argv = ['node', 'script.js', 'AsAd', '--iterations', '1000', '--no-color']
+  t.deepEqual(getInvalidHands(argv), [])
 })
 
 test('hasOption', t => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,6 +4,7 @@ import {
   numericalSort,
   convertToHex,
   parseCards,
+  findInvalidCards,
   percent,
   seconds,
   getStraight,
@@ -35,6 +36,14 @@ test('parseCards', t => {
   t.deepEqual(parseCards('....'), ['..', '..'])
   t.deepEqual(parseCards(''), undefined)
   t.deepEqual(parseCards('random string'), undefined)
+})
+
+test('findInvalidCards', t => {
+  t.deepEqual(findInvalidCards('Az3s6d'), ['Az'])
+  t.deepEqual(findInvalidCards('Az3z'), ['Az', '3z'])
+  t.deepEqual(findInvalidCards('Ts3s6d'), [])
+  t.deepEqual(findInvalidCards(''), [])
+  t.deepEqual(findInvalidCards(undefined), [])
 })
 
 test('percent', t => {


### PR DESCRIPTION
Adds `getInvalidHands` (console.js) and `findInvalidCards` (utils.js) to detect card-like tokens that fail validation, and prints a yellow warning in the CLI for both invalid hands and invalid board cards.